### PR TITLE
Adding constraints to the import to Germany and cleaning up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ results/
 resources/
 data/
 config/scenarios.automated.yaml
+config/scenarios.automated.import.yaml
 
 ## Core latex/pdflatex auxiliary files:
 *.aux

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,17 +6,10 @@
 run:
   prefix: import
   name:
-  # - no_import_me
-  # - eu_import_me_all
+  - no_import_me
+  - eu_import_me_all
   - all_import_me_all
-  # - CurrentPolicies
-  # - KN2045_Bal_v4
-  # - KN2045_Elec_v4
-  # - KN2045_H2_v4
-  # - KN2045plus_EasyRide
-  # - KN2045plus_LowDemand
-  # - KN2045minus_WorstCase
-  # - KN2045minus_SupplyFocus
+  # - all_import_me_all_100
   scenarios:
     enable: true
     manual_file: config/scenarios.manual.import.yaml
@@ -480,8 +473,6 @@ import:
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:
-  # TODO:
-  # shipping: false
   ammonia: true
   steel:
     endogenous: true
@@ -640,7 +631,7 @@ solving:
       fractional_last_unit_size: true
   constraints:
     limit_non_eu_de: false # true equals 0, number or false
-    limit_eu_de: false # true equals 0, number or false
+    limit_eu_de: false # true equals 0 or false
     limits_capacity_max:
       Generator:
         onwind:
@@ -680,7 +671,7 @@ solving:
       Generator:
         onwind:
           DE:
-            2030: 99   # Wind-an-Land Law 2028
+            2030: 99    # Wind-an-Land Law 2028
             2035: 115   # Wind-an-Land Law 2030
             2040: 115   # Wind-an-Land Law
             2045: 115
@@ -699,33 +690,6 @@ solving:
             2035: 101
             2040: 101
             2045: 101
-  # For reference, this are the values specified in the laws
-  # limits_capacity_min:
-  #     Generator:
-  #       onwind:
-  #         DE:
-  #           2030: 115 # Wind-an-Land Law
-  #           2035: 157 # Wind-an-Land Law
-  #           2040: 160 # Wind-an-Land Law
-  #           2045: 160
-  #       offwind:
-  #         DE:
-  #           2030: 30 # Wind-auf-See Law
-  #           2035: 40 # 40 Wind-auf-See Law
-  #           # assuming at least 1/3 of difference reached in 2040
-  #           2040: 50
-  #           2045: 70 #70 Wind-auf-See Law
-  #       solar:
-  #         DE:
-  #           # EEG2023; Ziel for 2024: 88 GW and for 2026: 128 GW,
-  #           # assuming at least 1/3 of difference reached in 2025
-  #           2025: 101
-  #           2030: 215 # PV strategy
-  #           2035: 309
-  #           2040: 400 # PV strategy
-  #           2045: 400
-  #           # What about the EEG2023 "Strommengenpfad"?
-    # boundary condition of maximum volumes
     limits_volume_max:
       # constrain electricity import in TWh
       electricity_import:
@@ -752,8 +716,6 @@ solving:
           2025: 0
           2030: 10
           2035: 105
-          2040: 200
-          2045: 300
       h2_import:
       # boundary condition lower?
         DE:
@@ -761,8 +723,6 @@ solving:
           2025: 5
           2030: 15
           2035: 115
-          2040: 220
-          2045: 325
       FT_production:
         DE:
           2020: 200

--- a/config/scenarios.manual.import.yaml
+++ b/config/scenarios.manual.import.yaml
@@ -13,7 +13,7 @@ no_import_me:
   solving:
     constraints:
       limit_non_eu_de: true # true equals 0, number or false
-      limit_eu_de: true # true equals 0, number or false
+      limit_eu_de: true # true equals 0 or false
       limits_capacity_min:
         Link:
           H2 Electrolysis:
@@ -39,7 +39,7 @@ eu_import_me_all:
   solving:
     constraints:
       limit_non_eu_de: true # true equals 0, number or false
-      limit_eu_de: false # true equals 0, number or false
+      limit_eu_de: false # true equals 0 or false
       limits_capacity_min:
         Link:
           H2 Electrolysis:
@@ -79,3 +79,29 @@ all_import_me_all:
     steam_biomass_fraction: 0.4
     steam_hydrogen_fraction: 0.3
     steam_electricity_fraction: 0.3
+
+all_import_me_all_100:
+# unlimited net import of energy carriers to Germany even from non-European countries
+
+  iiasa_database:
+    reference_scenario: KN2045_Bal_v4
+    fallback_reference_scenario: KN2045_Bal_v4
+  co2_budget_DE_source: KSG
+
+  solving:
+    constraints:
+      limit_non_eu_de: 100 # true equals 0, number or false
+      limit_eu_de: false # true equals 0 or false
+      limits_capacity_min:
+        Link:
+          H2 Electrolysis:
+            DE:
+              2030: 5
+
+  import:
+    enable: true
+
+  industry:
+    steam_biomass_fraction: 0.4
+    steam_hydrogen_fraction: 0.3
+    steam_electricity_fraction: 0.3 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -704,10 +704,8 @@ rule modify_final_network:
         temporal_clustering=config_provider("clustering", "temporal", "resolution_sector"),
         import_options=config_provider("import"),
         sector_options=config_provider("sector"),
-        industry_options=config_provider("industry"),
-        gas_network=config_provider("gas_network"),
-        h2_network=config_provider("h2_network"),
         costs=config_provider("costs"),
+        non_eu_constraint=config_provider("solving", "constraints", "limit_non_eu_de"),
     input:
         network=RESULTS
         + "prenetworks-final/base_s_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
@@ -718,7 +716,6 @@ rule modify_final_network:
         import_costs="import-data/imports/results-230505.csv",
         import_p_max_pu="import-data/imports/combined_weighted_generator_timeseries.nc",
         regions_onshore=resources("regions_onshore_base_s_{clusters}.geojson"),
-        country_shapes="data/naturalearth/ne_10m_admin_0_countries_deu.shp",
         country_centroids="import-data/countries_centroids.csv",
         costs=resources("costs_{planning_horizons}.csv"),
         clustered_pop_layout=resources("pop_layout_base_s_{clusters}.csv"),
@@ -728,11 +725,6 @@ rule modify_final_network:
         industrial_production_per_node=resources(
             "industrial_production_base_s_{clusters}_{planning_horizons}.csv"
         ),
-        industrial_energy_demand_per_node_today=resources(
-            "industrial_energy_demand_today_base_s_{clusters}.csv"
-        ),
-        # industrial_demand=resources("industrial_energy_demand_base_s_{clusters}_{planning_horizons}.csv"),
-        industrial_demand_today=resources("industrial_energy_demand_today_base_s_{clusters}.csv"),
         industrial_production=resources("industrial_production_base_s_{clusters}_{planning_horizons}.csv"),
     output:
         network=RESULTS

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -163,6 +163,8 @@ def add_power_limits(n, investment_year, limits_power_max):
 def h2_import_limits(n, investment_year, limits_volume_max):
 
     for ct in limits_volume_max["h2_import"]:
+        if investment_year not in limits_volume_max["h2_import"][ct].keys():
+            continue
         limit = limits_volume_max["h2_import"][ct][investment_year] * 1e6
 
         logger.info(f"limiting H2 imports in {ct} to {limit/1e6} TWh/a")
@@ -570,9 +572,11 @@ def force_boiler_profiles_existing_per_boiler(n):
     n.links["fixed_profile_scaling_opt"] = 0.0
 
 
-def add_h2_derivate_limit(n, investment_year, limits_volume_max):
+def add_h2_derivate_limit(n, investment_year, limits_volume_max, limit_non_eu_de):
 
     for ct in limits_volume_max["h2_derivate_import"]:
+        if investment_year not in limits_volume_max["h2_derivate_import"][ct].keys():
+            continue
         limit = limits_volume_max["h2_derivate_import"][ct][investment_year] * 1e6
 
         logger.info(f"limiting H2 derivate imports in {ct} to {limit/1e6} TWh/a")
@@ -584,19 +588,22 @@ def add_h2_derivate_limit(n, investment_year, limits_volume_max):
                 "EU renewable gas -> DE gas",
             ]
         ].index
-        outgoing = n.links.loc[
-            [
-                "DE renewable oil -> EU oil",
-                "DE methanol -> EU methanol",
-                "DE renewable gas -> EU gas",
-            ]
-        ].index
+        if not limit_non_eu_de:
+            outgoing = n.links.loc[
+                [
+                    "DE renewable oil -> EU oil",
+                    "DE methanol -> EU methanol",
+                    "DE renewable gas -> EU gas",
+                ]
+            ].index
+            outgoing_p = (
+                n.model["Link-p"].loc[:, outgoing] * n.snapshot_weightings.generators
+            ).sum()
+        else:
+            outgoing_p = 0
 
         incoming_p = (
             n.model["Link-p"].loc[:, incoming] * n.snapshot_weightings.generators
-        ).sum()
-        outgoing_p = (
-            n.model["Link-p"].loc[:, outgoing] * n.snapshot_weightings.generators
         ).sum()
 
         lhs = incoming_p - outgoing_p
@@ -660,19 +667,20 @@ def adapt_nuclear_output(n):
     )
 
 
-def remove_EU_import_limits(n):
+def remove_production_limits(n):
     """"
-    Remove any restrictions on the import of carriers from the EU.
+    Remove any restrictions on the production volumes of FT and H2.
     """
 
     logger.info("Removing any EU import limit constraints.")
 
     cnames = [
-        "H2_derivate_import_limit-DE",
-        # "H2_production_limit_upper-DE",
-        # "H2_production_limit_lower-DE",
-        "H2_import_limit-DE",
-        "Electricity_import_limit-DE",
+        # "H2_derivate_import_limit-DE",
+        "FT_production_volume_limit-DE",
+        "H2_production_limit_upper-DE",
+        "H2_production_limit_lower-DE",
+        # "H2_import_limit-DE",
+        # "Electricity_import_limit-DE",
     ]
 
     for cname in cnames:
@@ -682,205 +690,91 @@ def remove_EU_import_limits(n):
             n.model.constraints.remove("GlobalConstraint-" + cname)
 
 
-def import_limit_de(n, snapshots, limit_non_eu_de, limit_eu_de, investment_year):
+def import_limit_eu(n, sns, limit_eu_de, investment_year):
+    """
+    Limiting European imports to Germany to net 0 TWh for each carrier.
+    """
 
-    # if limit_non_eu_de:
-    #     logger.info("Limiting non-European imports")
-    #     import_gens = n.generators.loc[n.generators.carrier.str.contains("import") & n.generators.index.str.contains("DE")].index
-    #     import_links = n.links.loc[n.links.carrier.str.contains("import") & n.links.index.str.contains("DE")].index
+    rhs = 0
 
-    #     if isinstance(limit_non_eu_de, int):
-    #         limit = limit_non_eu_de
-    #     elif isinstance(limit_non_eu_de, dict):
-    #         limit = limit_non_eu_de[investment_year]
+    logger.info("Limiting European imports to Germany to net 0 TWh for each carrier.")
+    ct = "DE"
+    # collect indices of more complex carriers
+    h2_in = n.links.index[(n.links.carrier.str.contains("H2 pipeline")) & 
+                        (n.links.bus0.str[:2] != ct) &
+                        (n.links.bus1.str[:2] == ct)]
+    h2_out = n.links.index[(n.links.carrier.str.contains("H2 pipeline")) & 
+                        (n.links.bus0.str[:2] == ct) &
+                        (n.links.bus1.str[:2] != ct)]
+    elec_links_in = n.links.index[((n.links.carrier == "DC") | (n.links.carrier == "AC")) & (n.links.bus0.str[:2] != ct) & (n.links.bus1.str[:2] == ct)]
+    elec_links_out = n.links.index[((n.links.carrier == "DC") | (n.links.carrier == "AC")) & (n.links.bus0.str[:2] == ct) & (n.links.bus1.str[:2] != ct)]
 
-    #     if (import_gens.empty and import_links.empty):
-    #         return
+    elec_lines_in = n.lines.index[(n.lines.carrier == "AC") & (n.lines.bus0.str[:2] != ct) & (n.lines.bus1.str[:2] == ct)]
+    elec_lines_out = n.lines.index[(n.lines.carrier == "AC") & (n.lines.bus0.str[:2] == ct) & (n.lines.bus1.str[:2] != ct)]
+    
+    lhs_ele_s = n.model["Line-s"].loc[sns, elec_lines_in].sum() - n.model["Line-s"].loc[sns, elec_lines_out].sum()
+    lhs_ele_p = n.model["Link-p"].loc[sns, elec_links_in].sum() - n.model["Link-p"].loc[sns, elec_links_out].sum()
+    
+    lhs_h2 = n.model["Link-p"].loc[sns, h2_in].sum() - n.model["Link-p"].loc[sns, h2_out].sum()
+    
+    lhs_ft = n.model["Link-p"].loc[sns, "EU renewable oil -> DE oil"].sum() - n.model["Link-p"].loc[sns, "DE renewable oil -> EU oil"].sum()
+    lhs_meoh = n.model["Link-p"].loc[sns, "EU methanol -> DE methanol"].sum() - n.model["Link-p"].loc[sns, "DE methanol -> EU methanol"].sum()
+    lhs_gas = n.model["Link-p"].loc[sns, "EU renewable gas -> DE gas"].sum() - n.model["Link-p"].loc[sns, "DE renewable gas -> EU gas"].sum()
 
-    #     weightings = n.snapshot_weightings.loc[snapshots, "generators"]
+    lhs_nh3 = n.model["Link-p"].loc[sns, "EU NH3 -> DE NH3"].sum() - n.model["Link-p"].loc[sns, "DE NH3 -> EU NH3"].sum()
 
-    #     p_gens = n.model["Generator-p"].loc[snapshots, import_gens]
-    #     p_links = n.model["Link-p"].loc[snapshots, import_links]
+    lhs_steel = n.model["Link-p"].loc[sns, "EU steel -> DE steel"].sum() - n.model["Link-p"].loc[sns, "DE steel -> EU steel"].sum()
+    lhs_hbi = n.model["Link-p"].loc[sns, "EU hbi -> DE hbi"].sum() - n.model["Link-p"].loc[sns, "DE hbi -> EU hbi"].sum()
+    # electricity
+    n.model.add_constraints(lhs_ele_s, "==", rhs, name="import_limit_lines")
+    n.model.add_constraints(lhs_ele_p, "==", rhs, name="import_limit_ele")
+    # hydrogen
+    n.model.add_constraints(lhs_h2, "==", rhs, name="import_limit_h2")
+    # h2 derivatives
+    n.model.add_constraints(lhs_ft, "==", rhs, name="import_limit_ft")
+    n.model.add_constraints(lhs_meoh, "==", rhs, name="import_limit_meoh")
+    n.model.add_constraints(lhs_gas, "==", rhs, name="import_limit_gas")
+    n.model.add_constraints(lhs_nh3, "==", rhs, name="import_limit_nh3")
+    # steel and hbi
+    n.model.add_constraints(lhs_steel, "==", rhs, name="import_limit_steel")
+    n.model.add_constraints(lhs_hbi, "==", rhs, name="import_limit_hbi")
 
-    #     # using energy content of iron as proxy: 2.1 MWh/t hbi: 1.5 MWh/t
-    #     energy_weightings = np.where(import_gens.str.contains("steel"), 2.1, 1.0)
-    #     energy_weightings = np.where(import_gens.str.contains("hbi"), 1.5, energy_weightings)
-    #     energy_weightings = pd.Series(energy_weightings, index=import_gens)
 
-    #     lhs = (p_gens * weightings * energy_weightings).sum() + (p_links * weightings).sum()
+def import_limit_non_eu(n, sns, limit_non_eu_de, investment_year):
+    
+    logger.info("Adding a limit of {limit_non_eu_de} TWh of non-European imports.")
 
-    #     rhs = limit * 1e6
+    # get all non-European import links
+    non_eu_links = n.links[
+        (n.links.bus1.str[:2] == "DE") &
+        (n.links.carrier.str.contains("import"))
+        ].index
 
-    #     n.model.add_constraints(lhs, "==", rhs, name="energy_import_limit_non_eu_de")
+    weightings = n.snapshot_weightings.loc[sns, "generators"]
 
-    #     if "energy_import_limit_non_eu_de" not in n.global_constraints.index:
-    #         n.add(
-    #             "GlobalConstraint",
-    #             "energy_import_limit_non_eu_de",
-    #             constant=limit,
-    #             sense="==",
-    #             type="",
-    #             carrier_attribute="",
-    #         )
+    p_links = n.model["Link-p"].loc[sns, non_eu_links]
 
-    if limit_eu_de:
-        logger.info("Limiting European imports")
-        ct = "DE"
-        h2_in = n.links.index[(n.links.carrier.str.contains("H2 pipeline")) & 
-                          (n.links.bus0.str[:2] != ct) &
-                          (n.links.bus1.str[:2] == ct)]
-        h2_out = n.links.index[(n.links.carrier.str.contains("H2 pipeline")) & 
-                           (n.links.bus0.str[:2] == ct) &
-                           (n.links.bus1.str[:2] != ct)]
-        elec_links_in = n.links.index[((n.links.carrier == "DC") | (n.links.carrier == "AC")) & (n.links.bus0.str[:2] != ct) & (n.links.bus1.str[:2] == ct)]
-        elec_links_out = n.links.index[((n.links.carrier == "DC") | (n.links.carrier == "AC")) & (n.links.bus0.str[:2] == ct) & (n.links.bus1.str[:2] != ct)]
-        elec_lines_in = n.lines.index[(n.lines.carrier == "AC") & (n.lines.bus0.str[:2] != ct) & (n.lines.bus1.str[:2] == ct)]
-        elec_lines_out = n.lines.index[(n.lines.carrier == "AC") & (n.lines.bus0.str[:2] == ct) & (n.lines.bus1.str[:2] != ct)]
-        h2_der_in = n.links.loc[[
-            "EU renewable oil -> DE oil", 
-            "EU steel -> DE steel",
-            "EU NH3 -> DE NH3",
-            "EU methanol -> DE methanol",
-            "EU renewable gas -> DE gas",
-            ]].index
-        h2_der_out = n.links.loc[[
-            "DE renewable oil -> EU oil",
-            "DE steel -> EU steel",
-            "DE NH3 -> EU NH3",
-            "DE methanol -> EU methanol",
-            "DE renewable gas -> EU gas",
-            ]].index
-        
-        links_in = h2_in.append(elec_links_in).append(h2_der_in)
-        links_out = h2_out.append(elec_links_out).append(h2_der_out)
+    lhs = (p_links * weightings).sum()
 
-        incoming_link_p = n.model["Link-p"].loc[snapshots, links_in]
-        outgoing_link_p = n.model["Link-p"].loc[snapshots, links_out]
+    rhs = limit_non_eu_de * 1e6
 
-        incoming_line_p = n.model["Line-s"].loc[snapshots, elec_lines_in]
-        outgoing_line_p = n.model["Line-s"].loc[snapshots, elec_lines_out]
-        
-        if isinstance(limit_eu_de, bool):
-            limit = 0
-        elif isinstance(limit_eu_de, dict):
-            limit = limit_eu_de[investment_year]
-        elif isinstance(limit_eu_de, int):
-            limit = limit_eu_de
+    n.model.add_constraints(lhs, "==", rhs, name="energy_import_limit")
 
-        weightings = n.snapshot_weightings.loc[snapshots, "generators"]
+    # restrict hydrogen export
+    h2_links = n.links.index[
+        (n.links.bus0.str[:2] == "DE") &
+        (n.links.bus1.str[:2] != "DE") &
+        (n.links.carrier.str.contains("H2 pipeline"))
+    ]
+    lhs = (
+            n.model["Link-p"].loc[sns, h2_links] * n.snapshot_weightings.generators
+        ).sum()
 
-        # using energy content of iron as proxy: 2.1 MWh/t
-        # energy_weightings_in = np.where(links_in.str.contains("steel"), 2.1, 1.0)
-        # energy_weightings_in = pd.Series(energy_weightings_in, index=links_in)
-        # energy_weightings_out = np.where(links_out.str.contains("steel"), 2.1, 1.0)
-        # energy_weightings_out = pd.Series(energy_weightings_out, index=links_out)
+    n.model.add_constraints(lhs, "<=", 0, name="h2_export_limit_DE")
+    
+    # might be necessary to add constraint for electricity export as well
 
-        # lhs1 = (incoming_link_p * weightings * energy_weightings_in).sum() - (outgoing_link_p * weightings * energy_weightings_out).sum()
-        
-        lhs_ele_s = (incoming_line_p * weightings).sum() - (outgoing_line_p * weightings).sum()
-        lhs_h2 = (n.model["Link-p"].loc[snapshots, h2_in] * weightings).sum() - (n.model["Link-p"].loc[snapshots, h2_out] * weightings).sum()
-        lhs_ele_p = (n.model["Link-p"].loc[snapshots, elec_links_in] * weightings).sum() - (n.model["Link-p"].loc[snapshots, elec_links_out] * weightings).sum()
-        lhs_ft = (n.model["Link-p"].loc[snapshots, "EU renewable oil -> DE oil"] * weightings) - (n.model["Link-p"].loc[snapshots, "DE renewable oil -> EU oil"] * weightings)
-        lhs_steel = (n.model["Link-p"].loc[snapshots, "EU steel -> DE steel"] * weightings) - (n.model["Link-p"].loc[snapshots, "DE steel -> EU steel"] * weightings)
-        lhs_hbi = (n.model["Link-p"].loc[snapshots, "EU hbi -> DE hbi"] * weightings) - (n.model["Link-p"].loc[snapshots, "DE hbi -> EU hbi"] * weightings)
-        lhs_nh3 = (n.model["Link-p"].loc[snapshots, "EU NH3 -> DE NH3"] * weightings) - (n.model["Link-p"].loc[snapshots, "DE NH3 -> EU NH3"] * weightings)
-        lhs_meoh = (n.model["Link-p"].loc[snapshots, "EU methanol -> DE methanol"] * weightings) - (n.model["Link-p"].loc[snapshots, "DE methanol -> EU methanol"] * weightings)
-        lhs_gas = (n.model["Link-p"].loc[snapshots, "EU renewable gas -> DE gas"] * weightings) - (n.model["Link-p"].loc[snapshots, "DE renewable gas -> EU gas"] * weightings)
-        
-        rhs = limit * 1e6
 
-        n.model.add_constraints(lhs_ele_s, "==", rhs, name="import_limit_lines")
-
-        if "import_limit_lines" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_lines",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-
-        n.model.add_constraints(lhs_ele_p, "==", rhs, name="import_limit_ele")
-        if "import_limit_ele" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_ele",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-        n.model.add_constraints(lhs_h2, "==", rhs, name="import_limit_h2")
-        if "import_limit_h2" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_h2",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-        n.model.add_constraints(lhs_ft, "==", rhs, name="import_limit_ft")
-        if "import_limit_ft" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_ft",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-        n.model.add_constraints(lhs_steel, "==", rhs, name="import_limit_steel")
-        if "import_limit_steel" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_steel",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-        n.model.add_constraints(lhs_hbi, "==", rhs, name="import_limit_hbi")
-        if "import_limit_hbi" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_hbi",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-        n.model.add_constraints(lhs_nh3, "==", rhs, name="import_limit_nh3")
-        if "import_limit_nh3" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_nh3",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-        n.model.add_constraints(lhs_meoh, "==", rhs, name="import_limit_meoh")
-        if "import_limit_meoh" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_meoh",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-        n.model.add_constraints(lhs_gas, "==", rhs, name="import_limit_gas")
-        if "import_limit_gas" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_gas",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
 def FT_production_limit(n, investment_year, config):
     """ "
     Limit the production of FT fuels in a country to a certain volume.
@@ -921,193 +815,6 @@ def FT_production_limit(n, investment_year, config):
         )
 
 
-def import_limit_de(n, snapshots, limit_non_eu_de, limit_eu_de, investment_year):
-
-    if type(limit_non_eu_de) == int:
-        logger.info("Limiting non-European imports")
-        import_gens = n.generators.loc[n.generators.carrier.str.contains("import") & n.generators.index.str.contains("DE")].index
-        import_links = n.links.loc[n.links.carrier.str.contains("import") & n.links.index.str.contains("DE")].index
-
-        if isinstance(limit_non_eu_de, int):
-            limit = limit_non_eu_de
-        elif isinstance(limit_non_eu_de, dict):
-            limit = limit_non_eu_de[investment_year]
-
-        if (import_gens.empty and import_links.empty):
-            return
-
-        weightings = n.snapshot_weightings.loc[snapshots, "generators"]
-
-        p_gens = n.model["Generator-p"].loc[snapshots, import_gens]
-        p_links = n.model["Link-p"].loc[snapshots, import_links]
-
-        # using energy content of iron as proxy: 2.1 MWh/t hbi: 1.5 MWh/t
-        energy_weightings = np.where(import_gens.str.contains("steel"), 2.1, 1.0)
-        energy_weightings = np.where(import_gens.str.contains("hbi"), 1.5, energy_weightings)
-        energy_weightings = pd.Series(energy_weightings, index=import_gens)
-
-        lhs = (p_gens * weightings * energy_weightings).sum() + (p_links * weightings).sum()
-
-        rhs = limit * 1e6
-
-        n.model.add_constraints(lhs, "==", rhs, name="energy_import_limit_non_eu_de")
-
-        if "energy_import_limit_non_eu_de" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "energy_import_limit_non_eu_de",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-
-    if type(limit_eu_de) == int:
-        logger.info("Limiting European imports")
-        ct = "DE"
-        h2_in = n.links.index[(n.links.carrier.str.contains("H2 pipeline")) & 
-                          (n.links.bus0.str[:2] != ct) &
-                          (n.links.bus1.str[:2] == ct)]
-        h2_out = n.links.index[(n.links.carrier.str.contains("H2 pipeline")) & 
-                           (n.links.bus0.str[:2] == ct) &
-                           (n.links.bus1.str[:2] != ct)]
-        elec_links_in = n.links.index[((n.links.carrier == "DC") | (n.links.carrier == "AC")) & (n.links.bus0.str[:2] != ct) & (n.links.bus1.str[:2] == ct)]
-        elec_links_out = n.links.index[((n.links.carrier == "DC") | (n.links.carrier == "AC")) & (n.links.bus0.str[:2] == ct) & (n.links.bus1.str[:2] != ct)]
-        elec_lines_in = n.lines.index[(n.lines.carrier == "AC") & (n.lines.bus0.str[:2] != ct) & (n.lines.bus1.str[:2] == ct)]
-        elec_lines_out = n.lines.index[(n.lines.carrier == "AC") & (n.lines.bus0.str[:2] == ct) & (n.lines.bus1.str[:2] != ct)]
-        h2_der_in = n.links.loc[[
-            "EU renewable oil -> DE oil", 
-            "EU steel -> DE steel",
-            "EU NH3 -> DE NH3",
-            "EU methanol -> DE methanol",
-            "EU renewable gas -> DE gas",
-            ]].index
-        h2_der_out = n.links.loc[[
-            "DE renewable oil -> EU oil",
-            "DE steel -> EU steel",
-            "DE NH3 -> EU NH3",
-            "DE methanol -> EU methanol",
-            "DE renewable gas -> EU gas",
-            ]].index
-        
-        links_in = h2_in.append(elec_links_in).append(h2_der_in)
-        links_out = h2_out.append(elec_links_out).append(h2_der_out)
-
-        incoming_link_p = n.model["Link-p"].loc[snapshots, links_in]
-        outgoing_link_p = n.model["Link-p"].loc[snapshots, links_out]
-
-        incoming_line_p = n.model["Line-s"].loc[snapshots, elec_lines_in]
-        outgoing_line_p = n.model["Line-s"].loc[snapshots, elec_lines_out]
-        
-        if isinstance(limit_eu_de, int):
-            limit = limit_eu_de
-        elif isinstance(limit_eu_de, dict):
-            limit = limit_eu_de[investment_year]
-
-        weightings = n.snapshot_weightings.loc[snapshots, "generators"]
-
-        # using energy content of iron as proxy: 2.1 MWh/t
-        # energy_weightings_in = np.where(links_in.str.contains("steel"), 2.1, 1.0)
-        # energy_weightings_in = pd.Series(energy_weightings_in, index=links_in)
-        # energy_weightings_out = np.where(links_out.str.contains("steel"), 2.1, 1.0)
-        # energy_weightings_out = pd.Series(energy_weightings_out, index=links_out)
-
-        # lhs1 = (incoming_link_p * weightings * energy_weightings_in).sum() - (outgoing_link_p * weightings * energy_weightings_out).sum()
-        lhs2 = (incoming_line_p * weightings).sum() - (outgoing_line_p * weightings).sum()
-        lhs_h2 = (n.model["Link-p"].loc[snapshots, h2_in] * weightings).sum() - (n.model["Link-p"].loc[snapshots, h2_out] * weightings).sum()
-        lhs_ele = (n.model["Link-p"].loc[snapshots, elec_links_in] * weightings).sum() - (n.model["Link-p"].loc[snapshots, elec_links_out] * weightings).sum()
-        lhs_ft = (n.model["Link-p"].loc[snapshots, "EU renewable oil -> DE oil"] * weightings) - (n.model["Link-p"].loc[snapshots, "DE renewable oil -> EU oil"] * weightings)
-        lhs_steel = (n.model["Link-p"].loc[snapshots, "EU steel -> DE steel"] * weightings) - (n.model["Link-p"].loc[snapshots, "DE steel -> EU steel"] * weightings)
-        lhs_nh3 = (n.model["Link-p"].loc[snapshots, "EU NH3 -> DE NH3"] * weightings) - (n.model["Link-p"].loc[snapshots, "DE NH3 -> EU NH3"] * weightings)
-        lhs_methanol = (n.model["Link-p"].loc[snapshots, "EU methanol -> DE methanol"] * weightings) - (n.model["Link-p"].loc[snapshots, "DE methanol -> EU methanol"] * weightings)
-        lhs_gas = (n.model["Link-p"].loc[snapshots, "EU renewable gas -> DE gas"] * weightings) - (n.model["Link-p"].loc[snapshots, "DE renewable gas -> EU gas"] * weightings)
-        
-        rhs = limit * 1e6
-
-        n.model.add_constraints(lhs2, "==", rhs, name="import_limit_lines")
-
-        if "import_limit_lines" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_lines",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-
-        n.model.add_constraints(lhs_ele, "==", rhs, name="import_limit_ele")
-        if "import_limit_ele" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_ele",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-        n.model.add_constraints(lhs_h2, "==", rhs, name="import_limit_h2")
-        if "import_limit_h2" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_h2",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-        n.model.add_constraints(lhs_ft, "==", rhs, name="import_limit_ft")
-        if "import_limit_ft" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_ft",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-        n.model.add_constraints(lhs_steel, "==", rhs, name="import_limit_steel")
-        if "import_limit_steel" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_steel",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-        n.model.add_constraints(lhs_nh3, "==", rhs, name="import_limit_nh3")
-        if "import_limit_nh3" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_nh3",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-        n.model.add_constraints(lhs_methanol, "==", rhs, name="import_limit_meoh")
-        if "import_limit_meoh" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_meoh",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-        n.model.add_constraints(lhs_gas, "==", rhs, name="import_limit_gas")
-        if "import_limit_gas" not in n.global_constraints.index:
-            n.add(
-                "GlobalConstraint",
-                "import_limit_gas",
-                constant=limit,
-                sense="==",
-                type="",
-                carrier_attribute="",
-            )
-
-
 def additional_functionality(n, snapshots, snakemake):
 
     logger.info("Adding Ariadne-specific functionality")
@@ -1141,7 +848,7 @@ def additional_functionality(n, snapshots, snakemake):
         )
 
     if not snakemake.config["run"]["debug_h2deriv_limit"]:
-        add_h2_derivate_limit(n, investment_year, constraints["limits_volume_max"])
+        add_h2_derivate_limit(n, investment_year, constraints["limits_volume_max"], constraints["limit_non_eu_de"])
 
     # force_boiler_profiles_existing_per_load(n)
     force_boiler_profiles_existing_per_boiler(n)
@@ -1160,15 +867,15 @@ def additional_functionality(n, snapshots, snakemake):
     if investment_year == 2020:
         adapt_nuclear_output(n)
 
-    # TODO: what restrictions do I really need?
-    # restrict european import
-    # remove other boundary conditions on import import scenarios
     limit_eu_de = constraints["limit_eu_de"]
     limit_non_eu_de = constraints["limit_non_eu_de"]
 
-    # Remove any constraints on the import to add new ones
-    remove_EU_import_limits(n)
+    # Remove any production volume constraints
+    remove_production_limits(n)
 
-    if limit_eu_de: # or limit_non_eu_de:
-        logger.info("Adding import limit for Germany")
-        import_limit_de(n, snapshots, limit_non_eu_de, limit_eu_de, investment_year)
+    if limit_eu_de:
+        logger.info("Adding import limit for European imports to Germany.")
+        import_limit_eu(n, snapshots, limit_eu_de, investment_year)
+    if limit_non_eu_de:
+        logger.info("Adding import limit for non European imports to Germany.")
+        import_limit_non_eu(n, snapshots, limit_non_eu_de, investment_year)

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -815,6 +815,54 @@ def FT_production_limit(n, investment_year, config):
         )
 
 
+def ramp_up_limit_non_EU(n, n_snapshots, limits_volume_max, investment_year):
+
+    if investment_year not in limits_volume_max["h2_derivate_import"]["DE"].keys():
+        return
+    limit = limits_volume_max["h2_derivate_import"]["DE"][investment_year] * 1e6
+
+    logger.info(f"limiting non European H2 derivate imports to DE to {limit/1e6} TWh/a")
+
+    non_eu_links = n.links[
+        (n.links.bus1.str[:2] == "DE") &
+        (n.links.carrier.str.contains("import")) &
+        ~(n.links.carrier.str.contains("h2"))
+        ].index
+
+    incoming_p = (
+        n.model["Link-p"].loc[:, non_eu_links] * n.snapshot_weightings.generators
+    ).sum()
+
+    lhs = incoming_p
+
+    cname = "non_European_H2_derivate_import_limit-DE"
+
+    n.model.add_constraints(lhs <= limit, name=f"GlobalConstraint-{cname}")
+
+    if investment_year not in limits_volume_max["h2_import"]["DE"].keys():
+        return
+    limit = limits_volume_max["h2_import"]["DE"][investment_year] * 1e6
+
+    logger.info(f"limiting non European H2 imports to DE to {limit/1e6} TWh/a")
+
+    non_eu_links = n.links[
+        (n.links.bus1.str[:2] == "DE") &
+        (n.links.carrier.str.contains("import")) &
+        (n.links.carrier.str.contains("h2"))
+        ].index
+
+    incoming_p = (
+        n.model["Link-p"].loc[:, non_eu_links] * n.snapshot_weightings.generators
+    ).sum()
+
+    lhs = incoming_p
+
+    cname = "non_European_H2_import_limit-DE"
+
+    n.model.add_constraints(lhs <= limit, name=f"GlobalConstraint-{cname}")
+
+
+
 def additional_functionality(n, snapshots, snakemake):
 
     logger.info("Adding Ariadne-specific functionality")
@@ -876,6 +924,9 @@ def additional_functionality(n, snapshots, snakemake):
     if limit_eu_de:
         logger.info("Adding import limit for European imports to Germany.")
         import_limit_eu(n, snapshots, limit_eu_de, investment_year)
+    if 'import shipping-lh2' in n.links.carrier.unique():
+        logger.info("Ramp up import limit for non European imports to Germany.")
+        ramp_up_limit_non_EU(n, snapshots, constraints["limits_volume_max"], investment_year)
     if limit_non_eu_de:
         logger.info("Adding import limit for non European imports to Germany.")
         import_limit_non_eu(n, snapshots, limit_non_eu_de, investment_year)


### PR DESCRIPTION
Addressing https://github.com/toniseibold/pypsa-de-import/issues/4 and https://github.com/toniseibold/pypsa-de-import/issues/3

The following boundary conditions are now available:
- `limit_non_eu_de` 
**True**: 0 TWh of import allowed from non European partners only comes into effect with `config[import][enable]`
**int**: int TWh of import allowed from non European partners only comes into effect with `config[import][enable]`
Furthermore the export of energy carriers from Germany to Europe (excluding electricity) is forbidden. This leads force imports to be used within Germany.
**False**: unlimited import from non European partners
- `limit_eu_de`
**True** 0 TWh of net import for each carrier individually
**False** no restriction on import volumes from European partners
- `FT_import` and `H2_import` are kept to allow restriction of availability of those carriers in 2030 and 2035
if non European imports are allowed the same amount of imports from European partners and non European partners is allowed.


