### PR TITLE
Fixing constraints for eu and non eu scenarios

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -476,7 +476,7 @@ sector:
   ammonia: true
   steel:
     endogenous: true
-    relocation: false
+    relocation: true
     flexibility: false
   hvc: 
     endogenous: true

--- a/config/scenarios.manual.import.yaml
+++ b/config/scenarios.manual.import.yaml
@@ -12,7 +12,7 @@ no_import_me:
 
   solving:
     constraints:
-      limit_non_eu_de: true # true equals 0, number or false
+      limit_non_eu_de: false # true equals 0, number or false
       limit_eu_de: true # true equals 0 or false
       limits_capacity_min:
         Link:
@@ -38,7 +38,7 @@ eu_import_me_all:
 
   solving:
     constraints:
-      limit_non_eu_de: true # true equals 0, number or false
+      limit_non_eu_de: false # true equals 0, number or false
       limit_eu_de: false # true equals 0 or false
       limits_capacity_min:
         Link:


### PR DESCRIPTION
Addressing https://github.com/toniseibold/pypsa-de-import/issues/10

The following constraints are now applied in all scenarios:
- capacity limits (min and max for renewable energy expansion in Germany as well as electrolysis and sequestered CO2)
- power limit (max. import power for electricity)
- h2 import limit for 2030 and 2035
- h2 derivative import limit for 2030 and 2035
- electricity import limit for all years
- German CO2 target

**no_import**
- net import of each carrier crossing the German-European border must be zero

**eu_import**
- no further constraints

**non_eu_import**
- h2 (derivative) limit for non European imports in 2030 and 2035 in the same magnitude as European imports
