### PR TITLE
Clean up import options

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -490,7 +490,7 @@ sector:
     endogenous: true
     relocation: false
     flexibility: false
-  hvc: 
+  hvc:
     endogenous: true
     demand_factor: 1.0
   v2g: false

--- a/config/scenarios.manual.import.yaml
+++ b/config/scenarios.manual.import.yaml
@@ -104,4 +104,4 @@ all_import_me_all_100:
   industry:
     steam_biomass_fraction: 0.4
     steam_hydrogen_fraction: 0.3
-    steam_electricity_fraction: 0.3 
+    steam_electricity_fraction: 0.3

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -759,7 +759,9 @@ rule build_import_ports:
 
 rule modify_final_network:
     params:
-        temporal_clustering=config_provider("clustering", "temporal", "resolution_sector"),
+        temporal_clustering=config_provider(
+            "clustering", "temporal", "resolution_sector"
+        ),
         import_options=config_provider("import"),
         sector_options=config_provider("sector"),
         costs=config_provider("costs"),
@@ -781,13 +783,17 @@ rule modify_final_network:
         industry_sector_ratios=resources(
             "industry_sector_ratios_{planning_horizons}.csv"
         ),
-        industrial_production=resources("industrial_production_base_s_{clusters}_{planning_horizons}.csv"),
+        industrial_production=resources(
+            "industrial_production_base_s_{clusters}_{planning_horizons}.csv"
+        ),
         country_shapes="data/naturalearth/ne_10m_admin_0_countries_deu.shp",
     output:
         network=RESULTS
         + "prenetworks-final-import/base_s_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
     log:
-        RESULTS + 
-        logs("modify_final_network_s_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.log"),
+        RESULTS
+        + logs(
+            "modify_final_network_s_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.log"
+        ),
     script:
         "scripts/modify_final_network.py"

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -707,7 +707,9 @@ def remove_production_limits(n, investment_year, limits_volume_max):
 
     cnames = [
         "H2_derivate_import_limit-DE",
-        "FT_production_volume_limit-DE",
+        # "FT_production_volume_limit-DE",
+        "capacity_maximum-DE-Link-Fischer-Tropsch",
+        "capacity_maximum-DE-Link-methanolisation",
         "H2_production_limit_upper-DE",
         "H2_production_limit_lower-DE",
         # "H2_import_limit-DE",
@@ -733,11 +735,13 @@ def remove_production_limits(n, investment_year, limits_volume_max):
             "EU renewable oil -> DE oil",
             "EU methanol -> DE methanol",
             "EU renewable gas -> DE gas",
-            "EU NH3 -> DE NH3",
             "EU steel -> DE steel",
             "EU hbi -> DE hbi",
         ]
     ].index
+    
+    if "EU NH3 -> DE NH3" in n.links.index:
+        incoming = incoming.append("EU NH3 -> DE NH3")
 
     lhs = (
         n.model["Link-p"].loc[:, incoming] * n.snapshot_weightings.generators

--- a/workflow/scripts/build_import_ports.py
+++ b/workflow/scripts/build_import_ports.py
@@ -10,16 +10,15 @@ import json
 import logging
 
 import geopandas as gpd
-import pandas as pd
 import numpy as np
+import pandas as pd
+from _helpers import configure_logging, set_scenario_config
+from cluster_gas_network import load_bus_regions
 from scipy import spatial
 from scipy.sparse import csgraph
 from shapely.geometry import LineString, Point, Polygon
-from _helpers import configure_logging, set_scenario_config
-from cluster_gas_network import load_bus_regions
 
 logger = logging.getLogger(__name__)
-
 
 
 def voronoi_partition_pts(points, outline):

--- a/workflow/scripts/modify_sector_ratios.py
+++ b/workflow/scripts/modify_sector_ratios.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: : 2020-2024 The PyPSA-Eur Authors
 #
 # SPDX-License-Identifier: MIT


### PR DESCRIPTION
The option to import from non European partners was buggy since some of the import points needed to be translated to match the file `ports_s_68.csv`. Some other bugs were taken care of in the rule `modify_final_network.py`

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
